### PR TITLE
Fix diagnostic with empty resource name

### DIFF
--- a/c2c-extension/src/main/java/io/ballerina/c2c/diagnostics/TomlDiagnosticChecker.java
+++ b/c2c-extension/src/main/java/io/ballerina/c2c/diagnostics/TomlDiagnosticChecker.java
@@ -95,8 +95,11 @@ public class TomlDiagnosticChecker {
                     boolean resourceFound = false;
                     List<ResourceInfo> resourceInfoList = serviceInfo.getResourceInfo();
                     for (ResourceInfo resourceInfo : resourceInfoList) {
-                        String resourcePath = trimResourcePath(serviceName) + "/" +
-                                trimResourcePath(resourceInfo.getPath());
+                        String balResourceName = trimResourcePath(resourceInfo.getPath());
+                        String resourcePath = trimResourcePath(serviceName) + "/" + balResourceName;
+                        if (balResourceName.equals(".")) {
+                            resourcePath = trimResourcePath(serviceName);
+                        }
                         if (resourcePath.equals(trimResourcePath(path))) {
                             resourceFound = true;
                             break;


### PR DESCRIPTION
## Purpose
Fix  the issue where Toml diagnostic checker doesn't take resource with empty name into account when doing validations.