### PR TITLE
Add docker build option Support

### DIFF
--- a/c2c-extension-test/src/test/java/io/ballerina/c2c/test/JobTest.java
+++ b/c2c-extension-test/src/test/java/io/ballerina/c2c/test/JobTest.java
@@ -42,6 +42,7 @@ import static io.ballerina.c2c.test.utils.KubernetesTestUtils.getDockerImage;
  * Test cases for job resources.
  */
 public class JobTest {
+
     private static final Path SOURCE_DIR_PATH = Paths.get("src", "test", "resources", "job");
     private static final Path DOCKER_TARGET_PATH = SOURCE_DIR_PATH.resolve(DOCKER);
     private static final Path KUBERNETES_TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
@@ -49,7 +50,7 @@ public class JobTest {
 
     @Test
     public void testKubernetesJobGeneration() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "ballerina_job.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "ballerina_job.bal", "k8s"), 0);
 
         File dockerFile = DOCKER_TARGET_PATH.resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());

--- a/c2c-extension-test/src/test/java/io/ballerina/c2c/test/samples/DockerProjectTest.java
+++ b/c2c-extension-test/src/test/java/io/ballerina/c2c/test/samples/DockerProjectTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.c2c.test.samples;
+
+import io.ballerina.c2c.exceptions.KubernetesPluginException;
+import io.ballerina.c2c.test.utils.KubernetesTestUtils;
+import io.ballerina.c2c.utils.KubernetesUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.ballerina.c2c.KubernetesConstants.DOCKER;
+import static io.ballerina.c2c.test.utils.KubernetesTestUtils.getCommand;
+import static io.ballerina.c2c.test.utils.KubernetesTestUtils.getExposedPorts;
+import static io.ballerina.c2c.test.utils.KubernetesTestUtils.loadImage;
+
+/**
+ * Test cases for sample 5.
+ */
+public class DockerProjectTest extends SampleTest {
+
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("docker").resolve("project");
+    private static final String VERSION = "0.0.1";
+    private static final Path DOCKER_TARGET_PATH =
+            SOURCE_DIR_PATH.resolve("target").resolve(DOCKER).resolve("hello-" + VERSION);
+    private static final String DOCKER_IMAGE = "xlight05/hello:v1.0.0";
+
+    @BeforeClass
+    public void compileSample() throws IOException, InterruptedException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaProject(SOURCE_DIR_PATH), 0);
+    }
+
+    @Test
+    public void validateDockerfile() {
+        File dockerFile = DOCKER_TARGET_PATH.resolve("Dockerfile").toFile();
+        Assert.assertTrue(dockerFile.exists());
+    }
+
+    @Test
+    public void validateDockerImage() {
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
+        Assert.assertEquals(ports.size(), 2);
+        Assert.assertEquals(ports.get(0), "9095/tcp");
+        Assert.assertEquals(ports.get(1), "9096/tcp");
+        // Validate ballerina.conf in run command
+        Assert.assertEquals(getCommand(DOCKER_IMAGE).toString(),
+                "[/bin/sh, -c, java -Xdiag -cp \"hello-0.0.1.jar:jars/*\" 'hello/hello/0_0_1/$_init']");
+    }
+
+    @Test(groups = { "integration" })
+    public void deploySample() throws IOException, InterruptedException {
+        Assert.assertEquals(0, loadImage(DOCKER_IMAGE));
+    }
+
+    @AfterClass
+    public void cleanUp() throws KubernetesPluginException {
+        KubernetesUtils.deleteDirectory(DOCKER_TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
+    }
+}

--- a/c2c-extension-test/src/test/java/io/ballerina/c2c/test/samples/DockerSingleTest.java
+++ b/c2c-extension-test/src/test/java/io/ballerina/c2c/test/samples/DockerSingleTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.c2c.test.samples;
+
+import io.ballerina.c2c.exceptions.KubernetesPluginException;
+import io.ballerina.c2c.test.utils.KubernetesTestUtils;
+import io.ballerina.c2c.utils.KubernetesUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.ballerina.c2c.KubernetesConstants.DOCKER;
+import static io.ballerina.c2c.test.utils.KubernetesTestUtils.getCommand;
+import static io.ballerina.c2c.test.utils.KubernetesTestUtils.getExposedPorts;
+import static io.ballerina.c2c.test.utils.KubernetesTestUtils.loadImage;
+
+/**
+ * Test cases for sample 5.
+ */
+public class DockerSingleTest extends SampleTest {
+
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("docker").resolve("single");
+    private static final Path DOCKER_TARGET_PATH = SOURCE_DIR_PATH.resolve(DOCKER);
+    private static final String DOCKER_IMAGE = "service:latest";
+
+    @BeforeClass
+    public void compileSample() throws IOException, InterruptedException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "service.bal", "docker"), 0);
+    }
+
+    @Test
+    public void validateDockerfile() {
+        File dockerFile = DOCKER_TARGET_PATH.resolve("Dockerfile").toFile();
+        Assert.assertTrue(dockerFile.exists());
+    }
+
+    @Test
+    public void validateDockerImage() {
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9096/tcp");
+        // Validate ballerina.conf in run command
+        Assert.assertEquals(getCommand(DOCKER_IMAGE).toString(),
+                "[/bin/sh, -c, java -Xdiag -cp \"service.jar:jars/*\" '$_init']");
+    }
+
+    @Test(groups = { "integration" })
+    public void deploySample() throws IOException, InterruptedException {
+        Assert.assertEquals(0, loadImage(DOCKER_IMAGE));
+    }
+
+    @AfterClass
+    public void cleanUp() throws KubernetesPluginException {
+        KubernetesUtils.deleteDirectory(DOCKER_TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
+    }
+}

--- a/c2c-extension-test/src/test/java/io/ballerina/c2c/test/samples/Sample1Test.java
+++ b/c2c-extension-test/src/test/java/io/ballerina/c2c/test/samples/Sample1Test.java
@@ -60,7 +60,7 @@ public class Sample1Test extends SampleTest {
 
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "hello_world.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "hello_world.bal", "k8s"), 0);
         File artifactYaml = KUBERNETES_TARGET_PATH.resolve("hello_world.yaml").toFile();
         Assert.assertTrue(artifactYaml.exists());
         KubernetesClient client = new DefaultKubernetesClient();
@@ -125,7 +125,7 @@ public class Sample1Test extends SampleTest {
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
-    @Test(groups = {"integration"})
+    @Test(groups = { "integration" })
     public void deploySample() throws IOException, InterruptedException {
         Assert.assertEquals(0, KubernetesTestUtils.loadImage(DOCKER_IMAGE));
         Assert.assertEquals(0, KubernetesTestUtils.deployK8s(KUBERNETES_TARGET_PATH));

--- a/c2c-extension-test/src/test/java/io/ballerina/c2c/test/utils/KubernetesTestUtils.java
+++ b/c2c-extension-test/src/test/java/io/ballerina/c2c/test/utils/KubernetesTestUtils.java
@@ -72,6 +72,7 @@ import java.util.stream.Collectors;
  * Kubernetes test utils.
  */
 public class KubernetesTestUtils {
+
     private static final Logger log = LoggerFactory.getLogger(KubernetesTestUtils.class);
     private static final String JAVA_OPTS = "JAVA_OPTS";
     private static final Path DISTRIBUTION_PATH = Paths.get(FilenameUtils.separatorsToSystem(
@@ -157,7 +158,8 @@ public class KubernetesTestUtils {
      * @throws InterruptedException if an error occurs while compiling
      * @throws IOException          if an error occurs while writing file
      */
-    public static int compileBallerinaFile(Path sourceDirectory, String fileName, Map<String, String> envVar)
+    public static int compileBallerinaFile(Path sourceDirectory, String fileName, Map<String, String> envVar,
+                                           String buildOption)
             throws InterruptedException, IOException {
         Path ballerinaInternalLog = Paths.get(sourceDirectory.toAbsolutePath().toString(), "ballerina-internal.log");
         if (ballerinaInternalLog.toFile().exists()) {
@@ -165,7 +167,7 @@ public class KubernetesTestUtils {
             FileUtils.deleteQuietly(ballerinaInternalLog.toFile());
         }
 
-        ProcessBuilder pb = new ProcessBuilder(BALLERINA_COMMAND, BUILD, "--cloud=k8s", fileName);
+        ProcessBuilder pb = new ProcessBuilder(BALLERINA_COMMAND, BUILD, "--cloud=" + buildOption, fileName);
         log.info(COMPILING + sourceDirectory.resolve(fileName).normalize());
         log.debug(EXECUTING_COMMAND + pb.command());
         pb.directory(sourceDirectory.toFile());
@@ -252,7 +254,6 @@ public class KubernetesTestUtils {
         return exitCode;
     }
 
-
     /**
      * Send a request to URL and validate the message.
      *
@@ -273,7 +274,7 @@ public class KubernetesTestUtils {
                         host.equalsIgnoreCase("internal.pizzashack.com") ||
                         host.equalsIgnoreCase("burger.com")) {
                     // If host is matching return the IP address we want, not what is in DNS
-                    return new InetAddress[]{InetAddress.getByName("127.0.0.1")};
+                    return new InetAddress[]{ InetAddress.getByName("127.0.0.1") };
                 } else {
                     // Else, resolve from the DNS
                     return super.resolve(host);
@@ -349,9 +350,10 @@ public class KubernetesTestUtils {
      * @throws InterruptedException if an error occurs while compiling
      * @throws IOException          if an error occurs while writing file
      */
-    public static int compileBallerinaFile(Path sourceDirectory, String fileName) throws InterruptedException,
+    public static int compileBallerinaFile(Path sourceDirectory, String fileName, String buildOption)
+            throws InterruptedException,
             IOException {
-        return compileBallerinaFile(sourceDirectory, fileName, new HashMap<>());
+        return compileBallerinaFile(sourceDirectory, fileName, new HashMap<>(), buildOption);
     }
 
     /**

--- a/c2c-extension-test/src/test/resources/testng.xml
+++ b/c2c-extension-test/src/test/resources/testng.xml
@@ -29,6 +29,8 @@
             <class name="io.ballerina.c2c.test.samples.Sample5Test"/>
             <class name="io.ballerina.c2c.test.samples.Sample6Test"/>
             <class name="io.ballerina.c2c.test.samples.Sample7Test"/>
+            <class name="io.ballerina.c2c.test.samples.DockerProjectTest"/>
+            <class name="io.ballerina.c2c.test.samples.DockerSingleTest"/>
         </classes>
     </test>
 

--- a/c2c-extension/src/main/java/io/ballerina/c2c/ArtifactManager.java
+++ b/c2c-extension/src/main/java/io/ballerina/c2c/ArtifactManager.java
@@ -28,11 +28,19 @@ import io.ballerina.c2c.handlers.ServiceHandler;
 import io.ballerina.c2c.models.DeploymentModel;
 import io.ballerina.c2c.models.KubernetesContext;
 import io.ballerina.c2c.models.KubernetesDataHolder;
+import io.ballerina.c2c.models.ServiceModel;
 import io.ballerina.c2c.utils.KubernetesUtils;
+import io.ballerina.c2c.utils.TomlHelper;
+import io.ballerina.toml.api.Toml;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import org.ballerinax.docker.generator.models.DockerModel;
 
 import java.io.PrintStream;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.ballerinax.docker.generator.utils.DockerGenUtils.extractJarName;
 
@@ -40,6 +48,7 @@ import static org.ballerinax.docker.generator.utils.DockerGenUtils.extractJarNam
  * Generate and write artifacts to files.
  */
 public class ArtifactManager {
+
     private static final Map<String, String> instructions = new LinkedHashMap<>();
     private static final PrintStream OUT = System.out;
     private KubernetesDataHolder kubernetesDataHolder;
@@ -58,11 +67,27 @@ public class ArtifactManager {
     }
 
     /**
+     * Generates artifacts according to the cloud parameter in build options.
+     *
+     * @param cloudType Value of cloud field in build option.
+     * @throws KubernetesPluginException if an error occurs while generating artifacts
+     */
+    public void createArtifacts(String cloudType) throws KubernetesPluginException {
+        if (cloudType.equals("k8s")) {
+            createKubernetesArtifacts();
+        } else if (cloudType.equals("docker")) {
+            createDockerArtifacts();
+        } else {
+            throw new KubernetesPluginException("Unsupported cloud option");
+        }
+    }
+
+    /**
      * Generate kubernetes artifacts.
      *
      * @throws KubernetesPluginException if an error occurs while generating artifacts
      */
-    void createArtifacts() throws KubernetesPluginException {
+    public void createKubernetesArtifacts() throws KubernetesPluginException {
         // add default kubernetes instructions.
         setDefaultKubernetesInstructions();
         OUT.println("\nGenerating artifacts...");
@@ -78,6 +103,52 @@ public class ArtifactManager {
         }
 
         printInstructions();
+    }
+
+    public void createDockerArtifacts() throws KubernetesPluginException {
+        OUT.println("\nGenerating artifacts...");
+        List<ServiceModel> serviceModels = kubernetesDataHolder.getServiceModelList();
+        DeploymentModel deploymentModel = kubernetesDataHolder.getDeploymentModel();
+        for (ServiceModel serviceModel : serviceModels) {
+            ContainerPort containerPort = new ContainerPortBuilder()
+                    .withName(serviceModel.getPortName())
+                    .withContainerPort(serviceModel.getTargetPort())
+                    .withProtocol(KubernetesConstants.KUBERNETES_SVC_PROTOCOL)
+                    .build();
+            deploymentModel.addPort(containerPort);
+        }
+        DockerModel dockerModel = KubernetesUtils.getDockerModel(deploymentModel);
+        kubernetesDataHolder.setDockerModel(dockerModel);
+        modifyDockerModelWithToml();
+        new DockerHandler().createArtifacts();
+
+        instructions.put("\tExecute the below command to run the generated docker image: ",
+                "\tdocker run -d " + generatePortInstruction(dockerModel.getPorts()) + dockerModel.getName());
+        printInstructions();
+    }
+
+    private String generatePortInstruction(Set<Integer> ports) {
+        if (ports.size() == 0) {
+            return "";
+        }
+        StringBuilder output = new StringBuilder();
+        for (Integer port : ports) {
+            output.append("-p ").append(port).append(":").append(port).append(" ");
+        }
+        return output.toString();
+    }
+
+    private void modifyDockerModelWithToml() {
+        final String containerImage = "container.image";
+        Toml toml = kubernetesDataHolder.getBallerinaCloud();
+        if (toml != null) {
+            DockerModel dockerModel = kubernetesDataHolder.getDockerModel();
+            dockerModel.setName(TomlHelper.getString(toml, containerImage + ".name", dockerModel.getName()));
+            dockerModel
+                    .setRegistry(TomlHelper.getString(toml, containerImage + ".repository", null));
+            dockerModel.setTag(TomlHelper.getString(toml, containerImage + ".tag", dockerModel.getTag()));
+            dockerModel.setBaseImage(TomlHelper.getString(toml, containerImage + ".base", dockerModel.getBaseImage()));
+        }
     }
 
     private void printInstructions() {

--- a/c2c-extension/src/main/java/io/ballerina/c2c/handlers/DeploymentHandler.java
+++ b/c2c-extension/src/main/java/io/ballerina/c2c/handlers/DeploymentHandler.java
@@ -23,7 +23,6 @@ import io.ballerina.c2c.exceptions.KubernetesPluginException;
 import io.ballerina.c2c.models.ConfigMapModel;
 import io.ballerina.c2c.models.DeploymentModel;
 import io.ballerina.c2c.models.KubernetesContext;
-import io.ballerina.c2c.models.KubernetesDataHolder;
 import io.ballerina.c2c.models.PersistentVolumeClaimModel;
 import io.ballerina.c2c.models.SecretModel;
 import io.ballerina.c2c.utils.KubernetesUtils;
@@ -64,7 +63,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.ballerina.c2c.KubernetesConstants.BALLERINA_CONF_FILE_NAME;
 import static io.ballerina.c2c.KubernetesConstants.BALLERINA_CONF_MOUNT_PATH;
@@ -73,12 +71,10 @@ import static io.ballerina.c2c.KubernetesConstants.BALLERINA_RUNTIME;
 import static io.ballerina.c2c.KubernetesConstants.CONFIG_MAP_POSTFIX;
 import static io.ballerina.c2c.KubernetesConstants.DEPLOYMENT_FILE_POSTFIX;
 import static io.ballerina.c2c.KubernetesConstants.DEPLOYMENT_POSTFIX;
-import static io.ballerina.c2c.KubernetesConstants.EXECUTABLE_JAR;
 import static io.ballerina.c2c.KubernetesConstants.YAML;
 import static io.ballerina.c2c.utils.KubernetesUtils.getValidName;
 import static io.ballerina.c2c.utils.KubernetesUtils.isBlank;
 import static org.ballerinax.docker.generator.DockerGenConstants.REGISTRY_SEPARATOR;
-import static org.ballerinax.docker.generator.utils.DockerGenUtils.extractJarName;
 
 /**
  * Generates kubernetes deployment from annotations.
@@ -563,46 +559,7 @@ public class DeploymentHandler extends AbstractArtifactHandler {
         generate(deploymentModel);
         OUT.println();
         OUT.print("\t@kubernetes:Deployment \t\t\t - complete 1/1");
-        dataHolder.setDockerModel(getDockerModel(deploymentModel));
-    }
-
-    /**
-     * Create docker artifacts.
-     *
-     * @param deploymentModel Deployment model
-     */
-    private DockerModel getDockerModel(DeploymentModel deploymentModel) {
-        final KubernetesDataHolder dataHolder = KubernetesContext.getInstance().getDataHolder();
-        DockerModel dockerModel = dataHolder.getDockerModel();
-        String dockerImage = deploymentModel.getImage();
-        String imageTag = "latest";
-        if (dockerImage.contains(":")) {
-            imageTag = dockerImage.substring(dockerImage.lastIndexOf(":") + 1);
-            dockerImage = dockerImage.substring(0, dockerImage.lastIndexOf(":"));
-        }
-
-        dockerModel.setPkgId(dataHolder.getPackageID());
-        dockerModel.setBaseImage(deploymentModel.getBaseImage());
-        dockerModel.setRegistry(deploymentModel.getRegistry());
-        dockerModel.setName(dockerImage);
-        dockerModel.setTag(imageTag);
-        dockerModel.setEnableDebug(false);
-        dockerModel.setUsername(deploymentModel.getUsername());
-        dockerModel.setPassword(deploymentModel.getPassword());
-        dockerModel.setPush(deploymentModel.isPush());
-        dockerModel.setDockerConfig(deploymentModel.getDockerConfigPath());
-        dockerModel.setCmd(deploymentModel.getCmd());
-        dockerModel.setJarFileName(extractJarName(this.dataHolder.getJarPath()) + EXECUTABLE_JAR);
-        dockerModel.setPorts(deploymentModel.getPorts().stream()
-                .map(ContainerPort::getContainerPort)
-                .collect(Collectors.toSet()));
-        dockerModel.setUberJar(deploymentModel.isUberJar());
-        dockerModel.setService(true);
-        dockerModel.setDockerHost(deploymentModel.getDockerHost());
-        dockerModel.setDockerCertPath(deploymentModel.getDockerCertPath());
-        dockerModel.setBuildImage(deploymentModel.isBuildImage());
-        dockerModel.addCommandArg(deploymentModel.getCommandArgs());
-        return dockerModel;
+        dataHolder.setDockerModel(KubernetesUtils.getDockerModel(deploymentModel));
     }
 }
 

--- a/c2c-extension/src/main/java/io/ballerina/c2c/utils/TomlHelper.java
+++ b/c2c-extension/src/main/java/io/ballerina/c2c/utils/TomlHelper.java
@@ -129,7 +129,7 @@ public class TomlHelper {
     }
 
     public static Toml createK8sTomlFromProject(TomlDocument tomlDocument) {
-        TomlTableNode astNode = tomlDocument.tomlAstNode();
+        TomlTableNode astNode = tomlDocument.toml().rootNode();
         astNode.clearDiagnostics();
         astNode.addSyntaxDiagnostics(reportSyntaxDiagnostics(tomlDocument.syntaxTree()));
         return new Toml(astNode);

--- a/samples/docker/project/Ballerina.toml
+++ b/samples/docker/project/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "hello"
+name= "hello"
+version = "0.0.1"
+
+[build-options]
+observabilityIncluded = true
+cloud = "docker"

--- a/samples/docker/project/Kubernetes.toml
+++ b/samples/docker/project/Kubernetes.toml
@@ -1,0 +1,4 @@
+[container.image]
+name = "hello"
+repository = "xlight05"
+tag = "v1.0.0"

--- a/samples/docker/project/probe.bal
+++ b/samples/docker/project/probe.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+service http:Service /hello on new http:Listener(9096) {
+    resource function get world (http:Caller caller) returns error? {
+        check caller->respond("Resource is Ready");
+    }
+}

--- a/samples/docker/project/service.bal
+++ b/samples/docker/project/service.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+
+listener http:Listener helloWorldEP = new (9095);
+
+service /hello on helloWorldEP {
+    resource function get world(http:Caller caller, http:Request req) {
+        var result = caller->respond("Hello World!");
+        if (result is error) {
+            log:printError("Error in responding ", err = result);
+        }
+    }
+    resource function get . (http:Caller caller) returns error? {
+        check caller->respond("Resource is Ready");
+    }
+}

--- a/samples/docker/single/service.bal
+++ b/samples/docker/single/service.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+service http:Service /hello on new http:Listener(9096) {
+    resource function get world (http:Caller caller) returns error? {
+        check caller->respond("Resource is Ready");
+    }
+}


### PR DESCRIPTION
## Purpose
Earlier in code to cloud, we only k8s as the build options. This PR adds `k8s="docker"` as another build option. This allows users to only generate the docker related artifacts when using code to cloud.

## Samples
Ballerina.toml 
```toml
[package]
org = "anjana"
name = "hello"
version = "0.1.0"

[build-options]
observabilityIncluded = true
cloud = "docker"
```

Execute `ballerina build` 

Compiling source
        anjana/hello:0.1.0

Running Tests

        hello
        No tests found

Creating bala
        target/bala/anjana-hello-any-0.1.0.bala

Generating executable

Generating artifacts...

        @kubernetes:Docker                       - complete 2/2 

        Execute the below command to run the generated docker image: 
        docker run -d -p 9095:9095 -p 9096:9096 xlight05/hello:v1.0.0


        target/bin/hello-0.1.0.jar

Resolves #89