### PR TITLE
Add `-XX:+ExitOnOutOfMemoryError` flag

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "cloud"
-version = "3.3.2"
+version = "3.3.3"
 repository = "https://github.com/ballerina-platform/module-ballerina-c2c"
 license = ["Apache-2.0"]
 keywords = ["cloud", "kubernetes", "docker", "k8s", "c2c"]

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "code2cloud"
 class = "io.ballerina.c2c.C2CCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/cloud-compiler-plugin-3.3.2.jar"
+path = "../compiler-plugin/build/libs/cloud-compiler-plugin-3.3.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "cloud"
-version = "3.3.2"
+version = "3.3.3"
 modules = [
 	{org = "ballerina", packageName = "cloud", moduleName = "cloud"}
 ]

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/ComplexPackageNameTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/ComplexPackageNameTest.java
@@ -126,7 +126,8 @@ public class ComplexPackageNameTest {
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
         Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(),
-                "[java, -Xdiag, -cp, anjana-testObservation_0.1.5-0.1.0.jar:jars/*, " +
+                "[java, -XX:+ExitOnOutOfMemoryError, -Xdiag, -cp, " +
+                        "anjana-testObservation_0.1.5-0.1.0.jar:jars/*, " +
                         "anjana.testObservation_0&00461&00465.0.$_init]");
     }
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/MixedConfigJobTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/MixedConfigJobTest.java
@@ -157,8 +157,8 @@ public class MixedConfigJobTest {
 
     @Test
     public void validateDockerImage() {
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp," +
-                " anjana-mix_configs_job-0.1.0.jar:jars/*, anjana.mix_configs_job.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, anjana-mix_configs_job-0.1.0.jar:jars/*, anjana.mix_configs_job.0.$_init]");
     }
 
     @AfterClass

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/MixedConfigTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/MixedConfigTest.java
@@ -170,8 +170,8 @@ public class MixedConfigTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "anjana-mix_configs-0.1.0.jar:jars/*, anjana.mix_configs.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, anjana-mix_configs-0.1.0.jar:jars/*, anjana.mix_configs.0.$_init]");
     }
 
     @AfterClass

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/MultipleConfigTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/MultipleConfigTest.java
@@ -144,8 +144,8 @@ public class MultipleConfigTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
     }
 
     @AfterClass

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/SettingsFatJarTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/SettingsFatJarTest.java
@@ -57,8 +57,8 @@ public class SettingsFatJarTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp," +
-                " anjana-fat_jar-0.1.0.jar:jars/*, anjana.fat_jar.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, anjana-fat_jar-0.1.0.jar:jars/*, anjana.fat_jar.0.$_init]");
     }
 
     @AfterClass

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/choreo/PlainMainTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/choreo/PlainMainTest.java
@@ -73,8 +73,8 @@ public class PlainMainTest {
     public void validateDockerfile() throws IOException {
         File dockerFile = DOCKER_TARGET_PATH.resolve("Dockerfile").toFile();
         String dockerFileContent = new String(Files.readAllBytes(dockerFile.toPath()));
-        Assert.assertTrue(dockerFileContent.contains("ENTRYPOINT [\"java\",\"-Xdiag\",\"-cp\"," +
-                        "\"hello-hello-0.0.1.jar:jars/*\",\"hello.hello.0.$_init\"]"));
+        Assert.assertTrue(dockerFileContent.contains("ENTRYPOINT [\"java\",\"-XX:+ExitOnOutOfMemoryError\"," +
+                "\"-Xdiag\",\"-cp\",\"hello-hello-0.0.1.jar:jars/*\",\"hello.hello.0.$_init\"]"));
         Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
         Assert.assertTrue(dockerFile.exists());
     }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/choreo/PlainServiceTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/choreo/PlainServiceTest.java
@@ -77,8 +77,8 @@ public class PlainServiceTest {
     public void validateDockerfile() throws IOException {
         File dockerFile = DOCKER_TARGET_PATH.resolve("Dockerfile").toFile();
         String dockerFileContent = new String(Files.readAllBytes(dockerFile.toPath()));
-        Assert.assertTrue(dockerFileContent.contains("ENTRYPOINT [\"java\",\"-Xdiag\",\"-cp\"," +
-                "\"hello-hello-0.0.1.jar:jars/*\",\"hello.hello.0.$_init\"]"));
+        Assert.assertTrue(dockerFileContent.contains("ENTRYPOINT [\"java\",\"-XX:+ExitOnOutOfMemoryError\"," +
+                "\"-Xdiag\",\"-cp\",\"hello-hello-0.0.1.jar:jars/*\",\"hello.hello.0.$_init\"]"));
         Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
         Assert.assertTrue(dockerFile.exists());
     }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/docker/CmdTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/docker/CmdTest.java
@@ -59,8 +59,8 @@ public class CmdTest {
         Assert.assertTrue(FileUtils.readFileToString(dockerFile, StandardCharsets.UTF_8)
                 .contains("FROM ballerina/jre8:v1"));
         Assert.assertEquals(Arrays.toString(imageInspect.getConfig().getEntrypoint()),
-                "[/bin/sh, -c, [\"java\",\"-Xdiag\", \"-cp\", \"hello-hello-0.0.1.jar:jars/*\" \"$_init\" " +
-                        "\"--b7a.http.accesslog.console=true\"]");
+                "[/bin/sh, -c, [\"java\",\"-XX:+ExitOnOutOfMemoryError\",\"-Xdiag\", \"-cp\", " +
+                        "\"hello-hello-0.0.1.jar:jars/*\" \"$_init\" \"--b7a.http.accesslog.console=true\"]");
     }
 
     @AfterClass

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/docker/DockerCMDTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/docker/DockerCMDTest.java
@@ -69,7 +69,7 @@ public class DockerCMDTest {
         PackageID packageID = new PackageID(new Name("wso2"), new Name("bal"), new Name("1.0.0"));
         dockerModel.setPkgId(packageID);
         dockerModel.setDependencyJarPaths(jarFilePaths);
-        dockerModel.setEntryPoint("ENTRYPOINT java -Xdiag -cp '${APP}:jars/*' '$_init' " +
+        dockerModel.setEntryPoint("ENTRYPOINT java -XX:+ExitOnOutOfMemoryError -Xdiag -cp '${APP}:jars/*' '$_init' " +
                 "--b7a.http.accesslog.console=true");
         Path outputDir = SOURCE_DIR_PATH.resolve("target");
         Files.createDirectories(outputDir);
@@ -83,8 +83,8 @@ public class DockerCMDTest {
         Assert.assertNotNull(getDockerImage(DOCKER_IMAGE));
         InspectImageResponse imageInspect = getDockerImage(DOCKER_IMAGE);
         Assert.assertEquals(Arrays.toString(Objects.requireNonNull(imageInspect.getConfig()).getEntrypoint()),
-                "[/bin/sh, -c, java -Xdiag -cp 'hello.jar:jars/*' '$_init' --b7a.http.accesslog" +
-                        ".console=true]");
+                "[/bin/sh, -c, java -XX:+ExitOnOutOfMemoryError -Xdiag -cp 'hello.jar:jars/*' " +
+                        "'$_init' --b7a.http.accesslog.console=true]");
     }
 
     private Set<Path> getJarFilePaths() throws IOException {

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/docker/DockerGeneratorTests.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/docker/DockerGeneratorTests.java
@@ -121,8 +121,8 @@ public class DockerGeneratorTests {
 
         String dockerFileContent = new String(Files.readAllBytes(dockerFile.toPath()));
         cleaningUpDir = outputDir;
-        Assert.assertTrue(dockerFileContent.contains("ENTRYPOINT [\"java\",\"-Xdiag\"," +
-                "\"-cp\",\"hello.jar:jars/*\",\"wso2.bal.1.$_init\"]"));
+        Assert.assertTrue(dockerFileContent.contains("ENTRYPOINT [\"java\",\"-XX:+ExitOnOutOfMemoryError\"," +
+                "\"-Xdiag\",\"-cp\",\"hello.jar:jars/*\",\"wso2.bal.1.$_init\"]"));
         Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
     }
 
@@ -132,8 +132,8 @@ public class DockerGeneratorTests {
         Assert.assertEquals(DockerTestUtils.getExposedPorts(DOCKER_IMAGE).size(), 1);
         Assert.assertEquals(Objects.requireNonNull(DockerTestUtils.getDockerImage(DOCKER_IMAGE).getConfig()
                 .getEnv()).length, 8);
-        Assert.assertEquals(DockerTestUtils.getEntryPoint(DOCKER_IMAGE), Arrays.asList("java", "-Xdiag",
-                "-cp", "hello.jar:jars/*", "wso2.bal.1.$_init"));
+        Assert.assertEquals(DockerTestUtils.getEntryPoint(DOCKER_IMAGE), Arrays.asList("java",
+                "-XX:+ExitOnOutOfMemoryError", "-Xdiag", "-cp", "hello.jar:jars/*", "wso2.bal.1.$_init"));
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/DockerProjectTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/DockerProjectTest.java
@@ -64,8 +64,8 @@ public class DockerProjectTest extends SampleTest {
         Assert.assertEquals(ports.get(0), "9095/tcp");
         Assert.assertEquals(ports.get(1), "9096/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
     }
 
     @Test(groups = { "integration" })

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/DockerSingleTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/DockerSingleTest.java
@@ -63,7 +63,7 @@ public class DockerSingleTest extends SampleTest {
         Assert.assertEquals(ports.get(0), "9096/tcp");
         // Validate ballerina.conf in run command
         Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(),
-                "[java, -Xdiag, -cp, service.jar:jars/*, $_init]");
+                "[java, -XX:+ExitOnOutOfMemoryError, -Xdiag, -cp, service.jar:jars/*, $_init]");
     }
 
     @Test(groups = { "integration" })

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample10Test.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample10Test.java
@@ -109,8 +109,8 @@ public class Sample10Test extends SampleTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "8080/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
     }
 
     @Test(groups = { "integration" })

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample11Test.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample11Test.java
@@ -118,8 +118,8 @@ public class Sample11Test extends SampleTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
     }
 
     @AfterClass

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample12Test.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample12Test.java
@@ -129,8 +129,8 @@ public class Sample12Test extends SampleTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp," +
-                " hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
     }
 
     @Test(groups = { "integration" })

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample1Test.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample1Test.java
@@ -113,8 +113,8 @@ public class Sample1Test extends SampleTest {
     public void validateDockerfile() throws IOException {
         File dockerFile = DOCKER_TARGET_PATH.resolve("Dockerfile").toFile();
         String dockerFileContent = new String(Files.readAllBytes(dockerFile.toPath()));
-        Assert.assertTrue(dockerFileContent.contains("ENTRYPOINT [\"java\",\"-Xdiag\",\"-cp\"," +
-                "\"hello_world.jar:jars/*\",\"$_init\"]"));
+        Assert.assertTrue(dockerFileContent.contains("ENTRYPOINT [\"java\",\"-XX:+ExitOnOutOfMemoryError\"," +
+                "\"-Xdiag\",\"-cp\",\"hello_world.jar:jars/*\",\"$_init\"]"));
         Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
         Assert.assertTrue(dockerFile.exists());
     }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample2Test.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample2Test.java
@@ -129,8 +129,8 @@ public class Sample2Test extends SampleTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
     }
 
     @Test(groups = {"integration"})

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample5Test.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample5Test.java
@@ -160,8 +160,8 @@ public class Sample5Test extends SampleTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "xlight-hello-0.0.1.jar:jars/*, xlight.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, xlight-hello-0.0.1.jar:jars/*, xlight.hello.0.$_init]");
     }
 
     @Test(groups = { "integration" })

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample8Test.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample8Test.java
@@ -66,8 +66,8 @@ public class Sample8Test extends SampleTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
     }
 
     @AfterClass

--- a/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample9Test.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/c2c/test/samples/Sample9Test.java
@@ -111,8 +111,8 @@ public class Sample9Test extends SampleTest {
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -Xdiag, -cp, " +
-                "hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
+        Assert.assertEquals(getEntryPoint(DOCKER_IMAGE).toString(), "[java, -XX:+ExitOnOutOfMemoryError, " +
+                "-Xdiag, -cp, hello-hello-0.0.1.jar:jars/*, hello.hello.0.$_init]");
     }
 
     @Test(groups = { "integration" })

--- a/compiler-plugin-tests/src/test/resources/docker/cmd/Cloud.toml
+++ b/compiler-plugin-tests/src/test/resources/docker/cmd/Cloud.toml
@@ -2,5 +2,5 @@
 repository= "anuruddhal" # optional default is local
 name="cmd" # optional
 tag="v1"  # default is latest
-entrypoint="ENTRYPOINT [\"java\",\"-Xdiag\", \"-cp\", \"${APP}:jars/*\" \"$_init\" \"--b7a.http.accesslog.console=true\""
+entrypoint="ENTRYPOINT [\"java\",\"-XX:+ExitOnOutOfMemoryError\",\"-Xdiag\", \"-cp\", \"${APP}:jars/*\" \"$_init\" \"--b7a.http.accesslog.console=true\""
 base="ballerina/jre8:v1"

--- a/compiler-plugin/src/main/java/io/ballerina/c2c/utils/DockerGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/c2c/utils/DockerGenerator.java
@@ -236,6 +236,7 @@ public class DockerGenerator {
                     packageID.name.getValue(), packageID.version.getValue(), MODULE_INIT_CLASS_NAME);
             List<String> args = new ArrayList<>();
             args.add("java");
+            args.add("-XX:+ExitOnOutOfMemoryError");
             args.add("-Xdiag");
             if (this.dockerModel.isEnableDebug()) {
                 args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:" +


### PR DESCRIPTION
## Purpose
> Related to https://github.com/ballerina-platform/ballerina-lang/issues/44124

## Approach
> Add the `-XX:+ExitOnOutOfMemoryError` flag so the JVM terminates immediately when an OOM occurs