### PR TITLE
Update Alpine and JRE version

### DIFF
--- a/docker-images/base-image/Dockerfile
+++ b/docker-images/base-image/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.21.3
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # fontconfig and ttf-dejavu added to support serverside image generation by Java programs
-RUN apk upgrade --no-cache && apk add --no-cache fontconfig libretls musl-locales musl-locales-lang ttf-dejavu tzdata zlib libc6-compat gcompat libgcc\
+RUN apk add --no-cache fontconfig libretls musl-locales musl-locales-lang ttf-dejavu tzdata zlib libc6-compat gcompat libgcc \
     && rm -rf /var/cache/apk/*
 
 ENV JAVA_VERSION jdk-21.0.11+10
@@ -26,11 +26,11 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='b6f6a049d9b76b89b95a5da1f2bc9f9addc6e1052e3b3be575432e0fa773e9a0'; \
+         ESUM='b75c9f0dd052adfd213f0c2c1cc0c8a6d4539a8de9f7947d2b8fc45d18289975'; \
          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_x64_alpine-linux_hotspot_21.0.11_10.tar.gz'; \
          ;; \
        aarch64) \
-         ESUM='3dab98730234e1a87aec14bcb3e3947ef7a56c748e3b070cfe25aa5eb3e6fc2e'; \
+         ESUM='33399db5fb4f542df36a706d6642a3ba1fab3d247da707273a11ef29e39f0705'; \
          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_aarch64_alpine-linux_hotspot_21.0.11_10.tar.gz'; \
         ;;\
       *) \

--- a/docker-images/base-image/Dockerfile
+++ b/docker-images/base-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.20.7
+FROM alpine:3.21.3
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
@@ -20,34 +20,33 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apk upgrade --no-cache && apk add --no-cache fontconfig libretls musl-locales musl-locales-lang ttf-dejavu tzdata zlib libc6-compat gcompat libgcc\
     && rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk-21.0.8_9
-
+ENV JAVA_VERSION jdk-21.0.11+10
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-      amd64|x86_64) \
-          ESUM='f499e2d5c596fd531c8427b2fb207c9eeabed783adad32aeed64b03dd476a231'; \
-          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jre_x64_alpine-linux_hotspot_21.0.8_9.tar.gz'; \
+       amd64|x86_64) \
+         ESUM='b6f6a049d9b76b89b95a5da1f2bc9f9addc6e1052e3b3be575432e0fa773e9a0'; \
+         BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_x64_alpine-linux_hotspot_21.0.11_10.tar.gz'; \
          ;; \
-      aarch64) \
-          ESUM='f495749fce8d8974323f30428c1183168f90592dc90bb94c96edab33ffccc94e'; \
-          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jre_aarch64_alpine-linux_hotspot_21.0.8_9.tar.gz'; \
+       aarch64) \
+         ESUM='3dab98730234e1a87aec14bcb3e3947ef7a56c748e3b070cfe25aa5eb3e6fc2e'; \
+         BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_aarch64_alpine-linux_hotspot_21.0.11_10.tar.gz'; \
         ;;\
       *) \
          echo "Unsupported arch: ${ARCH}"; \
          exit 1; \
       ;; \
     esac; \
-	wget -O /tmp/openjdk.tar.gz ${BINARY_URL}; \
-	echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
-	mkdir -p /opt/java/openjdk; \
-	tar --extract \
-	    --file /tmp/openjdk.tar.gz \
-	    --directory /opt/java/openjdk \
-	    --strip-components 1 \
-	    --no-same-owner \
-	  ; \
+    wget -O /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/java/openjdk; \
+    tar --extract \
+        --file /tmp/openjdk.tar.gz \
+        --directory /opt/java/openjdk \
+        --strip-components 1 \
+        --no-same-owner \
+    ; \
     rm -rf /tmp/openjdk.tar.gz;
 
 ENV LD_PRELOAD=/lib/libgcompat.so.0


### PR DESCRIPTION
## Purpose
> Update Alpine and JRE version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request updates the Docker base image and related packaging to align with current platform releases and improve dependency handling:

- Bump Alpine Linux base image from 3.20.7 to 3.21.3.
- Upgrade embedded Temurin Java runtime from jdk-21.0.8_9 to jdk-21.0.11+10, including updated architecture-specific download URLs and SHA256 checksums for x86_64 and aarch64.
- Adjust apk usage to run apk upgrade --no-cache followed by apk add --no-cache and continue removing /var/cache/apk/*.
- Normalize formatting of the OpenJDK download, verification, and extraction steps in the Dockerfile.
- Add test resource ignore entries to .gitignore for compiler-plugin test artifacts and a GitHub instructions file.

Intent: keep the container image and runtime current, improve package handling in the Dockerfile, and exclude test-generated resources from version control to reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->