### PR TITLE
Add apk upgrade to base image Dockerfile

### DIFF
--- a/docker-images/base-image/Dockerfile
+++ b/docker-images/base-image/Dockerfile
@@ -17,9 +17,8 @@ FROM alpine:3.21.3
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # fontconfig and ttf-dejavu added to support serverside image generation by Java programs
-RUN apk update \
-    && apk add --no-cache fontconfig libretls musl-locales musl-locales-lang ttf-dejavu tzdata zlib libc6-compat gcompat libgcc \
-    && rm -rf /var/cache/apk/*
+RUN apk upgrade --no-cache \
+    && apk add --no-cache fontconfig libretls musl-locales musl-locales-lang ttf-dejavu tzdata zlib libc6-compat gcompat libgcc
 
 ENV JAVA_VERSION jdk-21.0.11+10
 

--- a/docker-images/base-image/Dockerfile
+++ b/docker-images/base-image/Dockerfile
@@ -17,7 +17,8 @@ FROM alpine:3.21.3
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # fontconfig and ttf-dejavu added to support serverside image generation by Java programs
-RUN apk add --no-cache fontconfig libretls musl-locales musl-locales-lang ttf-dejavu tzdata zlib libc6-compat gcompat libgcc \
+RUN apk update \
+    && apk add --no-cache fontconfig libretls musl-locales musl-locales-lang ttf-dejavu tzdata zlib libc6-compat gcompat libgcc \
     && rm -rf /var/cache/apk/*
 
 ENV JAVA_VERSION jdk-21.0.11+10


### PR DESCRIPTION
## Summary
- Added `apk upgrade --no-cache` before `apk add --no-cache` in the base image Dockerfile to upgrade all pre-installed Alpine base packages to their latest versions within the `alpine:3.21` release channel.

## Motivation
The Alpine base image (`alpine:3.21.3`) ships with a fixed set of pre-installed packages. Running `apk upgrade` at build time ensures any security or bug-fix patches released since the base image was published are applied, reducing the vulnerability surface of the final image. Using `--no-cache` keeps the image lean by fetching the index on-the-fly without writing to disk.